### PR TITLE
Prepare theme for zed.dev

### DIFF
--- a/.github/workflows/bump-extension.yml
+++ b/.github/workflows/bump-extension.yml
@@ -1,0 +1,18 @@
+name: Bump Zed Extension
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Bump version
+        uses: zed-industries/bump-zed-extension@v1
+        with:
+          path: extension.toml

--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ This theme collection is based on the excellent [Gruvbox Theme by jdinhify](http
 
 ### Continuous Integration
 
-This repository includes a GitHub workflow using the
-`bump-zed-extension` action. The workflow automatically bumps the
+This repository includes a GitHub workflow (located at `.github/workflows/bump-extension.yml`)
+using the `bump-zed-extension` action. The workflow automatically bumps the
 version in `extension.toml` when changes are pushed to the `main`
 branch, ensuring the package stays up to date for publishing on
 [zed.dev](https://zed.dev).
-
 ## Theme Variants
 
 This collection includes multiple variants of the Gruvbox Dark theme:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ This theme collection is based on the excellent [Gruvbox Theme by jdinhify](http
 4. Click "Install Dev Extension"
 5. Select the cloned repository directory
 
+### Continuous Integration
+
+This repository includes a GitHub workflow using the
+`bump-zed-extension` action. The workflow automatically bumps the
+version in `extension.toml` when changes are pushed to the `main`
+branch, ensuring the package stays up to date for publishing on
+[zed.dev](https://zed.dev).
+
 ## Theme Variants
 
 This collection includes multiple variants of the Gruvbox Dark theme:

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,12 @@
 id = "gruvbox-crisp-themes"
 name = "Gruvbox Crisp Themes"
-version = "0.1.3"
+version = "0.1.4"
 schema_version = 1
 authors = ["Vatsal Sanjay <vatsalsanjay@gmail.com>"]
 description = "Custom Gruvbox themes for Zed Editor with crisp high contrast variants"
 repository = "https://github.com/VatsalSy/zed-gruvbox_custom_themes"
+icon = "icon.png"
+
+[contributes]
+themes = ["themes/gruvbox-crisp-high-contrast.json"]
+


### PR DESCRIPTION
## Summary
- configure `extension.toml` with icon and contributed theme path
- document CI process in README
- add a GitHub workflow using `bump-zed-extension`

## Testing
- `git log -1 --stat`